### PR TITLE
ci: Add automerge GH action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.12.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Adds a new "automerge" GitHub action

Basically. If you assign the label "automerge" to any PR. It will ensure that:
- it syncs up with latest master
- checks pass
- before it is merged

This is very useful if you want a PR merged immediately after checks pass, but you don't want to keep checking when the checks have passed, or if you are merging multiple PRs and each merge requires all subsequent PRs to sync with latest master, and re-run checks.