### PR TITLE
Fix extra parameter bug at Add operation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -67,7 +67,7 @@ Format: `help`
 
 ### Adding a student: `add`
 
-Adds a student to the address book. 
+Adds a student to the address book.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM m/MATRIC_NUMBER [tg/TAG]…​`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -67,12 +67,12 @@ Format: `help`
 
 ### Adding a student: `add`
 
-Adds a student to the address book.
+Adds a student to the address book. 
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM m/MATRIC_NUMBER [tg/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-A student can have any number of tags (including 0)
+A student can have any number of tags (including 0). The rest of the parameters can **only** be inputted once.
 </div>
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -12,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all students in charge";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -39,9 +39,13 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TELEGRAM,
                         PREFIX_MATRIC_NUMBER, PREFIX_TAG);
+        // all argument checks
+        boolean areAllPrefixesPresent = arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_TELEGRAM, PREFIX_MATRIC_NUMBER);
+        boolean isPreambleEmpty = argMultimap.getPreamble().isEmpty();
+        boolean areDuplicatePrefixesPresent = checkDuplicatePrefixes(argMultimap);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TELEGRAM,
-                PREFIX_MATRIC_NUMBER) || !argMultimap.getPreamble().isEmpty()) {
+        if (!areAllPrefixesPresent || !isPreambleEmpty || areDuplicatePrefixesPresent) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
@@ -67,6 +71,15 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if there are duplicate prefixes(except for tag) in the given {@code ArgumentMultimap}.
+     */
+    private static boolean checkDuplicatePrefixes(ArgumentMultimap argumentMultimaps) {
+        Stream<Prefix> prefixes = Stream.of(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TELEGRAM,
+                PREFIX_MATRIC_NUMBER);
+        return prefixes.anyMatch(prefix -> argumentMultimaps.getAllValues(prefix).size() > 1);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -55,19 +55,9 @@ public class AddCommandParserTest {
                 + TELEGRAM_DESC_BOB + MATRIC_NUMBER_DESC_BOB + TAG_DESC_FRIEND,
                 new AddCommand(expectedPerson));
 
-        // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + TELEGRAM_DESC_BOB + MATRIC_NUMBER_DESC_BOB + TAG_DESC_FRIEND,
-                new AddCommand(expectedPerson));
-
-        // multiple phones - last phone accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TELEGRAM_DESC_BOB + MATRIC_NUMBER_DESC_BOB + TAG_DESC_FRIEND,
-                new AddCommand(expectedPerson));
-
-        // multiple emails - last email accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + TELEGRAM_DESC_BOB + MATRIC_NUMBER_DESC_BOB + TAG_DESC_FRIEND,
+        // single tag - all accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + TELEGRAM_DESC_BOB
+                        + MATRIC_NUMBER_DESC_BOB + TAG_DESC_FRIEND,
                 new AddCommand(expectedPerson));
 
         // multiple tags - all accepted


### PR DESCRIPTION
Closes #121 
Disables users from adding multiple parameters of the same type. Only multiple prefixes belonging to tags are permitted.