### PR TITLE
Fix Quick-Start guide URL

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -253,7 +253,7 @@ Format: `exportatt`
 
 **Q**: How do I start using TAsker?
 <br>
-**A**: Refer to our [Quick Start Guide](https://hackmd.io/@chrisgzf/TAskerUG#Quick-start) here.
+**A**: Refer to our [Quick Start Guide](https://ay2021s1-cs2103t-f11-1.github.io/tp/UserGuide.html#quick-start) here.
 <br>
 
 **Q**: How do I transfer my data to another Computer?<br>


### PR DESCRIPTION
Was still using the old working copy's draft URL.

Closes #125 