### PR TITLE
Prevent group consultations with differing locations

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddConsultCommand.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.consultation.Consultation;
+import seedu.address.model.consultation.exceptions.ConflictingGroupConsultationException;
 
 /**
  * Represents the command that is used to list all consultations, in classes.
@@ -33,6 +34,8 @@ public class AddConsultCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New consultation added: %1$s";
     public static final String MESSAGE_DUPLICATE_CONSULTATION = "This consultation slot has already been taken up!";
+    public static final String MESSAGE_WRONG_LOCATION_GROUP_CONSULTATION =
+            "Group consultations sharing the same time slot should be at the same location!";
 
     private final Consultation toAdd;
 
@@ -54,7 +57,12 @@ public class AddConsultCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_CONSULTATION);
         }
 
-        model.addConsultation(toAdd);
+        try {
+            model.addConsultation(toAdd);
+        } catch (ConflictingGroupConsultationException e) {
+            throw new CommandException(MESSAGE_WRONG_LOCATION_GROUP_CONSULTATION);
+        }
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/model/consultation/Consultation.java
+++ b/src/main/java/seedu/address/model/consultation/Consultation.java
@@ -92,6 +92,26 @@ public class Consultation {
     }
 
     /**
+     * Returns true if a Group consultation is added on the same time & day as another consultation.
+     *
+     * @param consultation Consultation to be added.
+     * @return Presence of conflicting consultation.
+     */
+    public boolean isGroupConsultationOnSameTimingAndDifferentLocation(Consultation consultation) {
+        if (consultation == this) {
+            return true;
+        }
+
+        // Group consultations can have same timing, but they must have the same location.
+        return consultation != null
+                && (consultation.getType().type.equals(ConsultationType.GROUP)
+                || getType().type.equals(ConsultationType.GROUP))
+                && consultation.getDate().equals(getDate())
+                && consultation.getTime().equals(getTime())
+                && !consultation.getLocation().equals(getLocation());
+    }
+
+    /**
      * Returns true if both consultation have the same data fields.
      * This defines a stronger notion of equality between two persons.
      *

--- a/src/main/java/seedu/address/model/consultation/UniqueConsultationList.java
+++ b/src/main/java/seedu/address/model/consultation/UniqueConsultationList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.consultation.exceptions.ConflictingGroupConsultationException;
 import seedu.address.model.consultation.exceptions.ConflictingPersonalConsultationException;
 import seedu.address.model.consultation.exceptions.ConsultationNotFoundException;
 import seedu.address.model.consultation.exceptions.DuplicateConsultationException;
@@ -59,7 +60,10 @@ public class UniqueConsultationList implements Iterable<Consultation> {
      * @param toAdd Consultation to add to the list.
      * @throws DuplicateConsultationException If consultation was already present.
      */
-    public void add(Consultation toAdd) {
+    public void add(Consultation toAdd) throws
+            DuplicateConsultationException,
+            ConflictingPersonalConsultationException,
+            ConflictingGroupConsultationException {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateConsultationException();
@@ -68,7 +72,15 @@ public class UniqueConsultationList implements Iterable<Consultation> {
         if (hasConflictingPersonalConsult(toAdd)) {
             throw new ConflictingPersonalConsultationException();
         }
+        // conflicting group consultation
+        if (hasConflictingGroupConsultation(toAdd)) {
+            throw new ConflictingGroupConsultationException();
+        }
         internalConsults.add(toAdd);
+    }
+
+    private boolean hasConflictingGroupConsultation(Consultation consultation) {
+        return internalConsults.stream().anyMatch(consultation::isGroupConsultationOnSameTimingAndDifferentLocation);
     }
 
     /**

--- a/src/main/java/seedu/address/model/consultation/exceptions/ConflictingGroupConsultationException.java
+++ b/src/main/java/seedu/address/model/consultation/exceptions/ConflictingGroupConsultationException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.consultation.exceptions;
+
+/**
+ * Signals that the operation will result in conflicting personal Consultations
+ * (Consultations are said to conflict if they match in time & date, but have various types such as
+ * personal vs personal, group vs personal).
+ */
+public class ConflictingGroupConsultationException extends RuntimeException {
+    public ConflictingGroupConsultationException() {
+        super("Group consultations sharing the same time slot should be at the same location!");
+    }
+}


### PR DESCRIPTION
Closes #173 

Could you run this locally @Rishi5154 and see if it fixes what you described in your issue?

You can run:

```
add-consult n/Alexe d/24/10/2020 tm/19:00 a/SOC Basement1  ty/group
add-consult n/Alexee d/24/10/2020 tm/19:00 a/SOC Basement2  ty/group
```